### PR TITLE
Update for new ember-cli-deploy compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Ember-deploy-azure
 
 This is the azure-adapter implementation to use both Azure Tables & CDN with
-[ember-deploy](https://github.com/levelbossmike/ember-deploy).
+[ember-cli-deploy](https://github.com/ember-cli/ember-cli-deploy).
 
 ## Installation & usage
 
-* `npm install ember-deploy-azure`
+* `npm install ember-cli-deploy ember-deploy-azure --save-dev`
 * update deploy.json to feature azure-adapters
 
 ## Accessing the index uploaded by index-adapter

--- a/lib/azure-assets.js
+++ b/lib/azure-assets.js
@@ -1,4 +1,4 @@
-var Adapter     = require('ember-deploy/utilities/adapter');
+var CoreObject  = require('core-object');
 var Promise     = require('ember-cli/lib/ext/promise');
 var SilentError = require('ember-cli/lib/errors/silent');
 var RSVP        = require('rsvp');
@@ -14,8 +14,9 @@ var white = chalk.white;
 
 var AZURE_CONTAINER_NAME = 'emberdeploy';
 
-module.exports = Adapter.extend({
+module.exports = CoreObject.extend({
   init: function() {
+    CoreObject.prototype.init.apply(this, arguments);
     if (!this.config) {
       return Promise.reject(new SilentError('You have to pass a config!'));
     }

--- a/lib/azure-index.js
+++ b/lib/azure-index.js
@@ -3,10 +3,9 @@ var azure       = require('azure-storage');
 var chalk       = require('chalk');
 var Promise     = require('ember-cli/lib/ext/promise');
 var SilentError = require('ember-cli/lib/errors/silent');
-var Adapter     = require('ember-deploy/utilities/adapter');
+var CoreObject  = require('core-object');
 
 var DEFAULT_MANIFEST_SIZE   = 10;
-var DEFAULT_TAGGING_ADAPTER = 'sha';
 
 var green = chalk.green;
 var white = chalk.white;
@@ -14,9 +13,9 @@ var white = chalk.white;
 var AZURE_TABLE_NAME = 'emberdeploy';
 var AZURE_MANIFEST_TAG = 'manifest';
 
-module.exports = Adapter.extend({
+module.exports = CoreObject.extend({
   init: function() {
-    this.tagging      = this.tagging || DEFAULT_TAGGING_ADAPTER;
+    CoreObject.prototype.init.apply(this, arguments);
     this.manifestSize = this.manifestSize || DEFAULT_MANIFEST_SIZE;
 
     if (!this.config) {
@@ -41,7 +40,7 @@ module.exports = Adapter.extend({
   },
 
   upload: function(value) {
-    var taggingAdapter = this.taggingAdapter || this._initTaggingAdapter();
+    var taggingAdapter = this.taggingAdapter;
     var key            = taggingAdapter.createTag();
 
     return this._upload(value, key);
@@ -167,14 +166,6 @@ module.exports = Adapter.extend({
           reject(error);
         }
       });
-    });
-  },
-
-  _initTaggingAdapter: function() {
-    var TaggingAdapter = require('ember-deploy/utilities/tagging/'+this.tagging);
-
-    return new TaggingAdapter({
-      manifest: this.manifest
     });
   },
 

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "broccoli": "^0.13.2",
     "broccoli-gzip": "^0.2.0",
     "chalk": "^0.5.1",
-    "ember-deploy": "^0.3.0",
+    "core-object": "^1.1.0",
     "mime": "^1.2.11",
     "rsvp": "^3.0.14",
     "walk": "^2.3.9"


### PR DESCRIPTION
Hello @duizendnegen 

This should make the plugin compatible with both ember-deploy and the new ember-cli-deploy. In order to do so, I've removed the dependency on the Adapter and replaced it with CoreObject. Additionally, the tagging adapter is passed in so there is no need to instantiate the tagging adapter directly.

I however do not have an azure account and was unable to verify this code with the plugin. Please take a look and let me know if you have any questions.
