### PR TITLE
Allow a custom container name to be specified on a per-environment basis

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,43 @@ https://gist.github.com/duizendnegen/85b5c4a7b7eef28f0756
 
 ## Accessing the assets / using a CDN
 
-Files are uploaded to `https://<STORAGE_NAME>.blob.core.windows.net/emberdeploy/<FILENAME>`.
+A container name can be specified in your `deploy.js` file by using the `containerName` property. If no container name is specified, it will default to _emberdeploy_. Here's a simple example:
+
+```javascript
+staging: {
+    buildEnv: 'staging',
+    store: {
+      type: 'redis',
+      host: '192.168.99.100',
+      port: 6379
+    },
+    assets: {
+      type: 'azure',
+      gzip: false,
+      storageAccount: process.env.AZURE_STORAGE_ACCOUNT_NAME,
+      storageAccessKey: process.env.AZURE_STORAGE_ACCESS_KEY,
+      containerName: 'myapp-staging'
+    }
+  },
+
+  production: {
+    store: {
+      type: 'redis',
+      host: '192.168.99.100', // ip address of your redis docker container
+      port: 6379
+    },
+    assets: {
+      type: 'azure',
+      gzip: false,
+      storageAccount: process.env.AZURE_STORAGE_ACCOUNT_NAME,
+      storageAccessKey: process.env.AZURE_STORAGE_ACCESS_KEY,
+      containerName: 'myapp-prod'
+    }
+  }
+
+```
+
+Files are uploaded to `https://<STORAGE_NAME>.blob.core.windows.net/[CONTAINER_NAME]/<FILENAME>`.
 A CDN can be pointed to this blob.
 
-Be sure to use the right fingerprinting to appropriately request the deployed assets: http://www.ember-cli.com/asset-compilation/ - this can either be `https://<STORAGE_NAME>.blob.core.windows.net/emberdeploy/` or `http://<CDN>.vo.msecnd.net/emberdeploy/`
+Be sure to use the right fingerprinting to appropriately request the deployed assets: http://www.ember-cli.com/asset-compilation/ - this can either be `https://<STORAGE_NAME>.blob.core.windows.net/[CONTAINER_NAME]/` or `http://<CDN>.vo.msecnd.net/[CONTAINER_NAME]/`

--- a/lib/azure-assets.js
+++ b/lib/azure-assets.js
@@ -32,6 +32,11 @@ module.exports = CoreObject.extend({
       console.error("No connection string or storage account plus access key set for this Azure deployment.");
       return Promise.reject(new SilentError('No connection string or storage account plus access key set for this Azure deployment.'));
     }
+
+    // if a storage container name is defined in the config, use it instead of the default
+    if(config.containerName) {
+      AZURE_CONTAINER_NAME = config.containerName;
+    }
   },
 
   upload: function() {


### PR DESCRIPTION
Currently, the plugin defaults to uploading assets to the 'emberdeploy' container. For those using multiple environments (dev, staging, prod, etc), it's nice to be able to specify a different container on a per-environment basis so assets aren't overwritten. This is similar to being able to specify a custom bucket in the `ember-deploy-s3` plugin. 
